### PR TITLE
Use official jest types

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "markdown-it": ">=12"
   },
   "devDependencies": {
-    "@types/jest": "28.1.4",
+    "@jest/types": "28.1.3",
     "@types/markdown-it": "12.2.3",
     "@typescript-eslint/eslint-plugin": "5.30.6",
     "@typescript-eslint/parser": "5.30.6",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,6 +7,7 @@
 import MarkdownIt from 'markdown-it/lib'
 
 import { imageSize } from '../src'
+import { describe, expect, it } from '@jest/globals'
 
 describe('markdown-it-imsize', function () {
   const md = new MarkdownIt({

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,7 +417,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hedgedoc/markdown-it-image-size@workspace:."
   dependencies:
-    "@types/jest": 28.1.4
+    "@jest/types": 28.1.3
     "@types/markdown-it": 12.2.3
     "@typescript-eslint/eslint-plugin": 5.30.6
     "@typescript-eslint/parser": 5.30.6
@@ -690,7 +690,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^28.1.1, @jest/types@npm:^28.1.3":
+"@jest/types@npm:28.1.3, @jest/types@npm:^28.1.1, @jest/types@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/types@npm:28.1.3"
   dependencies:
@@ -907,16 +907,6 @@ __metadata:
   dependencies:
     "@types/istanbul-lib-report": "*"
   checksum: f1ad54bc68f37f60b30c7915886b92f86b847033e597f9b34f2415acdbe5ed742fa559a0a40050d74cdba3b6a63c342cac1f3a64dba5b68b66a6941f4abd7903
-  languageName: node
-  linkType: hard
-
-"@types/jest@npm:28.1.4":
-  version: 28.1.4
-  resolution: "@types/jest@npm:28.1.4"
-  dependencies:
-    jest-matcher-utils: ^28.0.0
-    pretty-format: ^28.0.0
-  checksum: 97e22c600397bb4f30e39b595f8285ae92e4eb29a1ef6d1689749e4a4da683d88ecfe717b64492f6adc4c17c1c989520c3546f938c84a7d435c6ac3acf1a2bdc
   languageName: node
   linkType: hard
 
@@ -2779,7 +2769,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-matcher-utils@npm:^28.0.0, jest-matcher-utils@npm:^28.1.3":
+"jest-matcher-utils@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-matcher-utils@npm:28.1.3"
   dependencies:
@@ -3662,7 +3652,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^28.0.0, pretty-format@npm:^28.1.3":
+"pretty-format@npm:^28.1.3":
   version: 28.1.3
   resolution: "pretty-format@npm:28.1.3"
   dependencies:


### PR DESCRIPTION
### Description
This PR swaps `@types/jest` with `jest/type` as it is the official type package.

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/markdown-it-better-task-lists/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
